### PR TITLE
fixing version comparison to handle pre-releases

### DIFF
--- a/src/commands/enforce-gem-version-bump.yaml
+++ b/src/commands/enforce-gem-version-bump.yaml
@@ -38,7 +38,7 @@ steps:
 
         current_version_langauge="Current version [$EXISTING_VERSION]"
         primary_version_langauge="<< parameters.default-target >> version [$TARGET_VERSION]"
-        if dpkg --compare-versions "$EXISTING_VERSION" gt "$TARGET_VERSION"; then
+        if ruby -e "exit(1) unless Gem::Version.new('$EXISTING_VERSION') > Gem::Version.new('$TARGET_VERSION')"; then
           echo "Nice! Comparison is valid. $current_version_langauge is greater than $primary_version_langauge"
         else
           echo "Yikes! Comparison mismatch. $current_version_langauge is NOT greater than $primary_version_langauge"


### PR DESCRIPTION
## Problem
`dpkg` version comparison only handles Debian style beta version, does not understand SemVer or Ruby style pre-releases. 

```
# Debian style
$ dpkg --compare-versions '1.2.3' gt '1.2.3~beta.1' && echo 'true' || echo 'false'
true

# SemVer style 
$ dpkg --compare-versions '1.2.3' gt '1.2.3-beta.1' && echo 'true' || echo 'false'
false

# Ruby style 
$ dpkg --compare-versions '1.2.3' gt '1.2.3.beta.1' && echo 'true' || echo 'false'
false
```

## Solution
Use ruby one-liner instead 

```
# SemVer style (valid in Ruby)
$ ruby -e "exit(1) unless Gem::Version.new('1.2.3') > Gem::Version.new('1.2.3-beta.1')" && echo 'true' || echo 'false'
true

# Ruby style 
$ ruby -e "exit(1) unless Gem::Version.new('1.2.3') > Gem::Version.new('1.2.3.beta.1')" && echo 'true' || echo 'false'
true
```


